### PR TITLE
Test deletion and ALLOWED_GROUPS in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -114,6 +114,8 @@ jobs:
 
       - name: Delete fetch MCP server
         run: |
+          echo "=== fetch container logs ==="
+          docker logs fetch 2>&1 || true
           echo "Deleting fetch MCP server..."
           thv rm fetch
 
@@ -139,5 +141,3 @@ jobs:
           docker logs mcp-optimizer 2>&1 || true
           echo "=== time container logs ==="
           docker logs time 2>&1 || true
-          echo "=== fetch container logs ==="
-          docker logs fetch 2>&1 || true

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -167,8 +167,8 @@ async def test_mcp_optimizer_integration():
                 }
 
                 if os.getenv("ENABLE_DYNAMIC_INSTALL", False):
-                    expected_tools.append("search_registry")
-                    expected_tools.appedn("install_server")
+                    expected_tools.add("search_registry")
+                    expected_tools.add("install_server")
 
                 assert expected_tools.issubset(tool_names), (
                     f"Expected tools not found: {expected_tools - tool_names}"


### PR DESCRIPTION
- Add fetch MCP server installation alongside time server in integration tests
- Test server deletion by removing fetch server mid-workflow and verifying removal
- Run integration tests twice: once with fetch server present, once after deletion
- Add EXPECT_FETCH_ABSENT environment variable to control expected tools in tests
- Set WORKLOAD_POLLING_INTERVAL to 2 seconds for faster polling during tests
- Add verification step with sleep and status checks after deletion
- Add ALLOWED_GROUPS test to verify only serves in allowed groups are returned by mcp-optimizer