### PR TITLE
Remove URL manipulation in MCPServerClient

### DIFF
--- a/src/mcp_optimizer/mcp_client.py
+++ b/src/mcp_optimizer/mcp_client.py
@@ -128,6 +128,7 @@ class MCPServerClient:
             f"Using {proxy_mode} client for workload",
             workload=self.workload.name,
             proxy_mode_field=self.workload.proxy_mode,
+            url=self.workload.url,
         )
 
         try:


### PR DESCRIPTION
- Removed _prepare_url_for_proxy_mode method that appended /mcp or /sse paths
- Workload URLs now passed directly to underlying MCP clients without modification
- Eliminated temporary URL override logic in _execute_with_session
- Added 7 unit tests verifying URL remains unchanged during:
  - MCPServerClient initialization
  - list_tools operations (both streamable-http and SSE)
  - call_tool operations
  - Multiple consecutive operations
- All tests verify both the workload URL property and the URL passed to MCP clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)