### PR TITLE
Start server before workload and registry ingestion

### DIFF
--- a/src/mcp_optimizer/polling_manager.py
+++ b/src/mcp_optimizer/polling_manager.py
@@ -301,10 +301,6 @@ class PollingManager:
         # Store the event loop for later use by targeted polling
         self._loop = asyncio.get_running_loop()
 
-        startup_time_sec = min(self.workload_polling_interval, self.registry_polling_interval)
-        logger.info("Delaying polling start to allow server startup", seconds=startup_time_sec)
-        await asyncio.sleep(startup_time_sec)
-
         logger.info(
             "Creating polling tasks",
             workload_interval_seconds=self.workload_polling_interval,


### PR DESCRIPTION
Speed up server startup by moving ingestion to background

- Removed blocking registry and workload ingestion from server startup in `cli.py`
- Server now starts immediately after configuration validation and database migration
- Ingestion now happens asynchronously in the polling manager background thread
- Eliminated artificial startup delay in `polling_manager.py` that was waiting for minimum polling interval
- Background thread starts polling after 3-second grace period (to check for server shutdown) instead of waiting for initial ingestion to complete
- Server is ready to accept connections in seconds instead of minutes
- Ingestion failures no longer prevent server startup - polling will retry automatically

This change transforms the startup from synchronous blocking model to asynchronous background processing, dramatically reducing time-to-ready while maintaining the same functionality through the existing polling mechanism.