### PR TITLE
Fix update_thv_models GHA

### DIFF
--- a/.github/workflows/update-thv-models.yml
+++ b/.github/workflows/update-thv-models.yml
@@ -59,7 +59,9 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Ensure PR related actions (quality checks) are triggered, see
+          # https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092
+          token: ${{ secrets.UPDATE_THV_MODELS_GITHUB_TOKEN }}
           commit-message: |
             Update ToolHive API models
 


### PR DESCRIPTION
**Problem**

PRs created by the update_thv_models action are not triggering PR related actions (namely quality checks). This is a deliberate limitation imposed by GitHub Actions that an action cannot trigger other workflows. However, we want quality checks on this action since it is updating model code.

**Solution**

Based on [this discussion](https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092): GitHub is determining that API calls are coming from actions by checking the authentication token. If you use a repo scoped token instead of the default GITHUB_TOKEN then the on: pull_request workflow will run checks against the created pull request. As mentioned in the discussion, this is the workaround suggested by the Github support team.

As part of this change, I've created a repo-scoped PAT (with only PR r/w permissions) for stacklok's 'bot' account and saved it as a repo secret.