### PR TITLE
Fix release image provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
+          provenance: mode=max
           sbom: true
 
       - name: Install Cosign


### PR DESCRIPTION
Address #38 (which is now manifesting as `WARN	MCP server mcp-optimizer:latest has no provenance information set, skipping image verification`)

**Issue**
When you build for multiple platforms (`platforms: linux/amd64,linux/arm64`) with `provenance: true`, the attestation gets created but may not be properly associated with the manifest list. This is a known limitation in Docker buildx when dealing with multi-platform builds.

**Solution**
Use `provenance: mode=max` - This ensures provenance is properly attached even for multi-platform builds: