### PR TITLE
Add skipped-workloads to environment mapping

### DIFF
--- a/src/mcp_optimizer/cli.py
+++ b/src/mcp_optimizer/cli.py
@@ -32,9 +32,7 @@ TYPE_OVERRIDES = {
 
 # Fields that should not be exposed via CLI or environment variables
 # These fields can only be set via configuration files
-CLI_EXCLUDED_FIELDS = {
-    "skipped_workloads",  # Config-only field for workload filtering
-}
+CLI_EXCLUDED_FIELDS = {}
 
 
 def _generate_config_params():

--- a/src/mcp_optimizer/config.py
+++ b/src/mcp_optimizer/config.py
@@ -496,6 +496,7 @@ def _populate_config_from_env() -> dict[str, Any]:
         "WORKLOAD_INGESTION_BATCH_SIZE": "workload_ingestion_batch_size",
         "MAX_TOOL_RESPONSE_TOKENS": "max_tool_response_tokens",
         "ALLOWED_GROUPS": "allowed_groups",
+        "SKIPPED_WORKLOADS": "skipped_workloads",
         "RICH_TRACEBACKS": "rich_tracebacks",
         "COLORED_LOGS": "colored_logs",
         "K8S_API_SERVER_URL": "k8s_api_server_url",


### PR DESCRIPTION
This change will allow user to specify skipped-workloads in an environment variable.