### PR TITLE
Fix group filtering in Kubernetes mode and add example configurations

### DIFF
--- a/examples/mcp-servers/apply-mcp-servers.sh
+++ b/examples/mcp-servers/apply-mcp-servers.sh
@@ -55,6 +55,7 @@ kubectl apply -f "${EXAMPLES_DIR}/shared-serviceaccount.yaml"
 # Apply MCP servers
 echo ""
 echo "Applying MCP servers..."
+kubectl apply -f "${EXAMPLES_DIR}/mcpgroup_optimized.yaml"
 kubectl apply -f "${EXAMPLES_DIR}/mcpserver_fetch.yaml"
 kubectl apply -f "${EXAMPLES_DIR}/mcpserver_github.yaml"
 kubectl apply -f "${EXAMPLES_DIR}/mcpserver_toolhive-doc-mcp.yaml"

--- a/examples/mcp-servers/mcpgroup_optimized.yaml
+++ b/examples/mcp-servers/mcpgroup_optimized.yaml
@@ -1,0 +1,8 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPGroup
+metadata:
+  name: optimized
+  namespace: toolhive-system
+spec:
+  description: "Optimized MCP servers for tool discovery"
+

--- a/examples/mcp-servers/mcpserver_github.yaml
+++ b/examples/mcp-servers/mcpserver_github.yaml
@@ -13,6 +13,7 @@ spec:
   permissionProfile:
     name: network
     type: builtin
+  groupRef: optimized
   secrets:
     - name: github-token
       key: token

--- a/examples/mcp-servers/mcpserver_mcp-optimizer.yaml
+++ b/examples/mcp-servers/mcpserver_mcp-optimizer.yaml
@@ -83,6 +83,8 @@ spec:
               value: "sqlite+aiosqlite:///data/mcp_optimizer.db"
             - name: DB_URL
               value: "sqlite:///data/mcp_optimizer.db"
+            - name: ALLOWED_GROUPS
+              value: "optimized"
   resources:
     limits:
       cpu: 1000m

--- a/examples/mcp-servers/mcpserver_toolhive-doc-mcp.yaml
+++ b/examples/mcp-servers/mcpserver_toolhive-doc-mcp.yaml
@@ -13,6 +13,7 @@ spec:
     name: network
     type: builtin
   serviceAccount: mcp-shared-sa
+  groupRef: optimized
   podTemplateSpec:
     spec:
       containers:

--- a/src/mcp_optimizer/toolhive/k8s_client.py
+++ b/src/mcp_optimizer/toolhive/k8s_client.py
@@ -171,7 +171,8 @@ class K8sClient:
 
         # Get labels and group
         labels = metadata.get("labels", {})
-        group = labels.get("toolhive.stacklok.dev/group", "default")
+        # Prefer spec.groupRef over label (MCPServer CRD uses spec.groupRef)
+        group = spec.get("groupRef") or labels.get("toolhive.stacklok.dev/group", "default")
 
         # Package is typically the image name
         package = image


### PR DESCRIPTION
## Summary

This PR fixes group filtering in Kubernetes mode and adds example MCP server configurations demonstrating group usage.

## Changes

### Bug Fix: Group Reading in Kubernetes Mode
- **Fixed**  to read group from  instead of labels
- Previously, the optimizer was reading groups from  label, but MCPServer CRDs use  to reference MCPGroup resources
- This fix ensures group filtering works correctly when using  environment variable

### Example Configurations
- **Added**  - Example MCPGroup resource named "optimized"
- **Updated**  - Added  to assign github server to optimized group
- **Updated**  - Added  to assign toolhive-doc-mcp server to optimized group  
- **Updated**  - Added  environment variable to restrict tool discovery to only the optimized group
- **Updated**  - Added MCPGroup to the apply script

## Testing

The changes have been tested in a kind cluster with:
- MCPGroup "optimized" created
- github and toolhive-doc-mcp servers assigned to the optimized group
- mcp-optimizer configured with ALLOWED_GROUPS=optimized
- Verified that group filtering correctly restricts tool discovery to only servers in the optimized group