### PR TITLE
Fix all typecheck errors

### DIFF
--- a/src/mcp_optimizer/db/base_server_ops.py
+++ b/src/mcp_optimizer/db/base_server_ops.py
@@ -216,12 +216,14 @@ class BaseServerOps(ABC):
         self,
         server_id: str,
         conn: AsyncConnection | None = None,
+        **kwargs: Any,
     ) -> None:
         """Delete server (cascades to tools).
 
         Args:
             server_id: Server UUID
             conn: Optional connection
+            **kwargs: Additional subclass-specific parameters
         """
         query = f"DELETE FROM {self.server_table_name} WHERE id = :id"
         await self.db.execute_non_query(query, {"id": server_id}, conn=conn)

--- a/src/mcp_optimizer/db/base_tool_ops.py
+++ b/src/mcp_optimizer/db/base_tool_ops.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import structlog
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from mcp_optimizer.db.config import DatabaseConfig
 from mcp_optimizer.db.exceptions import DbNotFoundError
 from mcp_optimizer.db.models import (
-    BaseToolWithMetadata,
     McpStatus,
     RegistryTool,
     RegistryToolUpdateDetails,
@@ -637,7 +636,10 @@ class BaseToolOps(ABC):
         self,
         semantic_task: Awaitable,
         bm25_task: Awaitable,
-    ) -> tuple[list[BaseToolWithMetadata], list[BaseToolWithMetadata]]:
+    ) -> tuple[
+        list[RegistryToolWithMetadata] | list[WorkloadToolWithMetadata],
+        list[RegistryToolWithMetadata] | list[WorkloadToolWithMetadata],
+    ]:
         """Execute hybrid search tasks concurrently.
 
         Args:
@@ -1003,7 +1005,10 @@ class BaseToolOps(ABC):
             tool_distances=tool_distances,
         )
 
-        return tools_with_metadata
+        # Cast to the expected return type
+        return cast(
+            list[RegistryToolWithMetadata] | list[WorkloadToolWithMetadata], tools_with_metadata
+        )
 
     def _combine_search_results(
         self,

--- a/src/mcp_optimizer/db/workload_server_ops.py
+++ b/src/mcp_optimizer/db/workload_server_ops.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import structlog
@@ -180,9 +180,12 @@ class WorkloadServerOps(BaseServerOps):
         Returns:
             WorkloadWithRegistry if found (with registry if linked), None otherwise
         """
-        workload = await self.get_server_by_id(server_id, conn=conn)
-        if not workload:
+        server = await self.get_server_by_id(server_id, conn=conn)
+        if not server:
             return None
+
+        # Cast to WorkloadServer since this is WorkloadServerOps
+        workload = cast(WorkloadServer, server)
 
         # Get registry if linked
         registry = None

--- a/src/mcp_optimizer/mcp_client.py
+++ b/src/mcp_optimizer/mcp_client.py
@@ -160,6 +160,13 @@ class MCPServerClient:
                 )
 
         # Fallback to URL-based detection for backwards compatibility
+        if not self.workload.url:
+            logger.warning(
+                "No proxy_mode or URL available, defaulting to SSE",
+                workload=self.workload.name,
+            )
+            return ToolHiveProxyMode.SSE
+
         logger.debug(
             "No proxy_mode available, falling back to URL-based detection",
             workload=self.workload.name,

--- a/src/mcp_optimizer/toolhive/toolhive_client.py
+++ b/src/mcp_optimizer/toolhive/toolhive_client.py
@@ -494,6 +494,11 @@ class ToolhiveClient:
         """
         workload_list = await self.list_workloads(all_workloads=False)
 
+        # Handle case where workloads might be None
+        if not workload_list.workloads:
+            logger.info("No workloads found")
+            return []
+
         running_mcp_workloads = [
             workload
             for workload in workload_list.workloads


### PR DESCRIPTION
## Summary
Fixed all typecheck errors in the codebase, reducing diagnostics from 30+ (with multiple errors) to 9 warnings.

## Changes Made

### Type Annotation Fixes
- Fixed `_combine_search_results` and `_fetch_tools_with_metadata` in base_tool_ops.py to properly handle union types with cast()
- Updated `_execute_hybrid_search_tasks` return type to use proper union types

### Method Override Fixes
- Updated base_server_ops.py `delete_server` to accept `**kwargs` for subclass extensibility
- Fixed registry_server_ops.py to extract `workload_ops` from kwargs in `delete_server` override
- Added cast for `update_server` return type to narrow from union to specific type

### Type Narrowing
- Added cast in workload_server_ops.py to narrow `get_server_by_id` return type to WorkloadServer

### Extended MCP Content Type Support
- Extended token_limiter.py to support AudioContent and ResourceLink types from MCP protocol
- Added handling logic for the new content types in token counting and processing

### Null Safety Improvements
- Added null check in toolhive_client.py for workload list iteration
- Added fallback values ("unknown") for potentially None server names in ingestion.py
- Added null check in mcp_client.py for workload URL with SSE fallback
- Added validation to skip remote servers without URLs in registry ingestion

## Test Plan
- Ran `task typecheck` - all errors resolved, only 9 informational warnings remain
- Ran `task format` - code properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)