### PR TITLE
Fix workload discovery broken after toolhive removed tool_type field

### DIFF
--- a/src/mcp_optimizer/toolhive/k8s_client.py
+++ b/src/mcp_optimizer/toolhive/k8s_client.py
@@ -333,9 +333,7 @@ class K8sClient:
         all_workloads = await self.list_mcpservers(all_namespaces=True)
 
         running_mcp_workloads = [
-            workload
-            for workload in all_workloads
-            if workload.status == "running" and workload.tool_type in ["mcp", "remote"]
+            workload for workload in all_workloads if workload.status == "running"
         ]
 
         logger.info(

--- a/src/mcp_optimizer/toolhive/toolhive_client.py
+++ b/src/mcp_optimizer/toolhive/toolhive_client.py
@@ -646,9 +646,7 @@ class ToolhiveClient:
             return []
 
         running_mcp_workloads = [
-            workload
-            for workload in workload_list.workloads
-            if (workload.status == "running" and workload.tool_type == "mcp")
+            workload for workload in workload_list.workloads if workload.status == "running"
         ]
 
         logger.info(


### PR DESCRIPTION
Fixes #167

After toolhive PR #2932 removed the tool_type field from the Workload API response, mcp-optimizer could not discover any MCP servers. All workloads were filtered out because the tool_type field was null.

## Changes
- Remove tool_type filtering from workload discovery in ingestion.py (Docker and K8s modes)
- Remove tool_type filtering from toolhive_client.py and k8s_client.py
- Update logging to use remote field instead of tool_type for workload classification
- Update workload counting logic to use remote boolean field

The remote field now indicates workload type: remote=true for remote workloads, remote=false or null for container workloads.

## Testing
- All 284 tests pass
- Linting and type checking pass with no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)