### PR TITLE
Make security checks fail in CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Run Security Scanning
         run: task security
-        continue-on-error: true  # Don't fail the build on security issues, but report them
 
       - name: Generate SBOM
         run: task sbom

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,8 +46,8 @@ tasks:
   security:
     desc: Run security scanning
     cmds:
-      # Note: safety tool has compatibility issues with current environment
-      # - uv run safety check --save-json safety-report.json || true
+      - uv run bandit -r src/
+      - uv run pip-audit
       - uv run bandit -r src/ -f json -o bandit-report.json || true
       - uv run pip-audit --format=json --output=pip-audit-report.json || true
     deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "pytest-cov>=7.0.0",
 ]
 security = [
-    "safety>=3.7.0",
     "bandit[toml]>=1.9.2",
     "pip-audit>=2.10.0",
     "cyclonedx-bom>=7.2.1",

--- a/src/mcp_optimizer/cli.py
+++ b/src/mcp_optimizer/cli.py
@@ -240,7 +240,7 @@ def main(**kwargs: Any) -> None:
         logger.info("Starting server")
         uvicorn.run(
             "mcp_optimizer.server:starlette_app",
-            host="0.0.0.0",
+            host="0.0.0.0",  # nosec B104 - Intentionally bind to all interfaces for server accessibility
             port=config.mcp_port,
             log_config=logging_dict,
             reload=config.reload_server,

--- a/src/mcp_optimizer/config.py
+++ b/src/mcp_optimizer/config.py
@@ -577,7 +577,7 @@ def load_config() -> MCPOptimizerConfig:
         # Skip for /tmp and /data - let SQLite handle file creation in writable locations
         if config.db_url.startswith("sqlite://"):
             db_path = Path(config.db_url.replace("sqlite://", ""))
-            if not str(db_path).startswith(("/tmp", "/data")):
+            if not str(db_path).startswith(("/tmp", "/data")):  # nosec B108 - Checking paths to skip secure setup, not insecure usage
                 _setup_secure_database_path(db_path)
             else:
                 logger.info(f"Using writable database location: {db_path}")

--- a/src/mcp_optimizer/db/base_server_ops.py
+++ b/src/mcp_optimizer/db/base_server_ops.py
@@ -114,7 +114,7 @@ class BaseServerOps(ABC):
         Raises:
             DbNotFoundError: If server not found
         """
-        query = f"SELECT * FROM {self.server_table_name} WHERE id = :id"
+        query = f"SELECT * FROM {self.server_table_name} WHERE id = :id"  # nosec B608 - Table name is code-controlled, params are safe
         results = await self.db.execute_query(query, {"id": server_id}, conn=conn)
         if not results:
             raise DbNotFoundError(
@@ -146,7 +146,7 @@ class BaseServerOps(ABC):
         Raises:
             DbNotFoundError: If server not found
         """
-        query = f"SELECT * FROM {self.server_table_name} WHERE name = :name"
+        query = f"SELECT * FROM {self.server_table_name} WHERE name = :name"  # nosec B608 - Table name is code-controlled, params are safe
         results = await self.db.execute_query(query, {"name": name}, conn=conn)
         if not results:
             raise DbNotFoundError(
@@ -196,7 +196,7 @@ class BaseServerOps(ABC):
             f'"{field}" = :{field}' if field == "group" else f"{field} = :{field}"
             for field in update_fields.keys()
         ]
-        query = f"UPDATE {self.server_table_name} SET {', '.join(set_clauses)} WHERE id = :id"
+        query = f"UPDATE {self.server_table_name} SET {', '.join(set_clauses)} WHERE id = :id"  # nosec B608 - Table name is code-controlled, params are safe
 
         # Add server_id to params
         params = update_fields.copy()
@@ -225,7 +225,7 @@ class BaseServerOps(ABC):
             conn: Optional connection
             **kwargs: Additional subclass-specific parameters
         """
-        query = f"DELETE FROM {self.server_table_name} WHERE id = :id"
+        query = f"DELETE FROM {self.server_table_name} WHERE id = :id"  # nosec B608 - Table name is code-controlled, params are safe
         await self.db.execute_non_query(query, {"id": server_id}, conn=conn)
         logger.info(f"Deleted {self.server_table_name} server", server_id=server_id)
 
@@ -271,7 +271,7 @@ class BaseServerOps(ABC):
         {where_sql}
         ORDER BY created_at DESC
         {limit_sql}
-        """
+        """  # nosec B608 - Table name is code-controlled, params are safe
 
         results = await self.db.execute_query(query, params, conn=conn)
         servers = []
@@ -301,7 +301,7 @@ class BaseServerOps(ABC):
         """
         if server_id is not None:
             # Sync specific server
-            delete_query = f"DELETE FROM {self.vector_table_name} WHERE server_id = :server_id"
+            delete_query = f"DELETE FROM {self.vector_table_name} WHERE server_id = :server_id"  # nosec B608 - Table name is code-controlled, params are safe
             await self.db.execute_non_query(delete_query, {"server_id": server_id}, conn=conn)
 
             # Get server and insert if it has embedding
@@ -310,7 +310,7 @@ class BaseServerOps(ABC):
                 insert_query = f"""
                 INSERT INTO {self.vector_table_name} (server_id, embedding)
                 VALUES (:server_id, :embedding)
-                """
+                """  # nosec B608 - Table name is code-controlled, params are safe
                 params = {
                     "server_id": server_id,
                     "embedding": server.server_embedding.tobytes(),
@@ -319,14 +319,14 @@ class BaseServerOps(ABC):
                 logger.debug(f"Synced {self.vector_table_name} server vector", server_id=server_id)
         else:
             # Sync all servers - rebuild entire virtual table
-            delete_all_query = f"DELETE FROM {self.vector_table_name}"
+            delete_all_query = f"DELETE FROM {self.vector_table_name}"  # nosec B608 - Table name is code-controlled, params are safe
             await self.db.execute_non_query(delete_all_query, {}, conn=conn)
 
             # Get all servers with embeddings
             query = f"""
             SELECT id, server_embedding FROM {self.server_table_name}
             WHERE server_embedding IS NOT NULL
-            """
+            """  # nosec B608 - Table name is code-controlled, params are safe
             results = await self.db.execute_query(query, {}, conn=conn)
 
             # Batch insert
@@ -336,7 +336,7 @@ class BaseServerOps(ABC):
                 insert_query = f"""
                 INSERT INTO {self.vector_table_name} (server_id, embedding)
                 VALUES (:server_id, :embedding)
-                """
+                """  # nosec B608 - Table name is code-controlled, params are safe
                 params = {
                     "server_id": server_id_val,
                     "embedding": embedding_bytes,
@@ -393,7 +393,7 @@ class BaseServerOps(ABC):
         {group_filter}
         AND k = :limit
         ORDER BY sv.distance
-        """
+        """  # nosec B608 - Table names are code-controlled, params are safe
 
         # Add group parameters
         if allowed_groups:
@@ -435,7 +435,7 @@ class BaseServerOps(ABC):
         SELECT * FROM {self.server_table_name}
         WHERE id IN ({placeholders})
         ORDER BY created_at
-        """
+        """  # nosec B608 - Table name is code-controlled, params are safe
 
         params_details = {f"id{i}": server_id for i, server_id in enumerate(server_ids_filtered)}
         server_results = await self.db.execute_query(details_query, params_details, conn=conn)

--- a/src/mcp_optimizer/db/workload_tool_ops.py
+++ b/src/mcp_optimizer/db/workload_tool_ops.py
@@ -157,7 +157,7 @@ class WorkloadToolOps(BaseToolOps):
         JOIN mcpservers_workload s ON t.mcpserver_id = s.id
         WHERE s.status = :status
         {group_filter}
-        """
+        """  # nosec B608 - Table names are code-controlled, params are safe
 
         results = await self.db.execute_query(query, params, conn=conn)
         total_tokens = results[0]._mapping["total_tokens"] if results else 0

--- a/src/mcp_optimizer/server.py
+++ b/src/mcp_optimizer/server.py
@@ -83,7 +83,7 @@ class McpInstallationError(McpOptimizerError):
 
 
 # Initialize FastMCP - port will be overridden during startup
-mcp = FastMCP(name="mcp-optimizer", host="0.0.0.0", port=9900)
+mcp = FastMCP(name="mcp-optimizer", host="0.0.0.0", port=9900)  # nosec B104 - Intentionally bind to all interfaces for server accessibility
 
 # Global instances - will be initialized with proper config values
 embedding_manager: EmbeddingManager | None = None

--- a/src/mcp_optimizer/toolhive/k8s_client.py
+++ b/src/mcp_optimizer/toolhive/k8s_client.py
@@ -17,7 +17,7 @@ from mcp_optimizer.toolhive.api_models.core import Workload
 logger = structlog.get_logger(__name__)
 
 # In-cluster service account paths
-SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"  # nosec B105 - Standard Kubernetes service account path, not a hardcoded password
 SERVICE_ACCOUNT_CA_CERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 SERVICE_ACCOUNT_NAMESPACE_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
@@ -366,8 +366,8 @@ def get_k8s_namespace() -> str:
             namespace = namespace_path.read_text().strip()
             if namespace:
                 return namespace
-    except Exception:
-        pass
+    except Exception as e:  # nosec B110 - Intentional fallback to default namespace
+        logger.debug("Failed to read namespace from service account, using default", error=str(e))
 
     # Default to 'default' namespace
     return "default"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -802,18 +802,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dparse"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/ee/96c65e17222b973f0d3d0aa9bad6a59104ca1b0eb5b659c25c2900fccd85/dparse-0.6.4.tar.gz", hash = "sha256:90b29c39e3edc36c6284c82c4132648eaf28a01863eb3c231c2512196132201a", size = 27912, upload-time = "2024-11-08T16:52:06.444Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/26/035d1c308882514a1e6ddca27f9d3e570d67a0e293e7b4d910a70c8fe32b/dparse-0.6.4-py3-none-any.whl", hash = "sha256:fbab4d50d54d0e739fbb4dedfc3d92771003a5b9aa8545ca7a7045e3b174af57", size = 11925, upload-time = "2024-11-08T16:52:03.844Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1482,15 +1470,6 @@ wheels = [
 ]
 
 [[package]]
-name = "joblib"
-version = "1.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
-]
-
-[[package]]
 name = "jsonpointer"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1818,15 +1797,6 @@ wheels = [
 ]
 
 [[package]]
-name = "marshmallow"
-version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/81/edb105b3296712a282680bc1ae02b8c1bb45d8f1edad3ff9fab1d41e9507/marshmallow-4.1.1.tar.gz", hash = "sha256:550aa14b619072f0a8d8184911b3f1021c5c32587fb27318ddf81ce0d0029c9d", size = 220720, upload-time = "2025-12-05T22:56:09.282Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/c9/4364652639e3aa952f9e941c38a4f88a0eb29fcbb7bd642fe2de4322c834/marshmallow-4.1.1-py3-none-any.whl", hash = "sha256:9038db4cceb849ce2b8676ccf3d8e5b5e634ac499e291397efa260aa796c385a", size = 48295, upload-time = "2025-12-05T22:56:07.415Z" },
-]
-
-[[package]]
 name = "matplotlib"
 version = "3.10.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1946,7 +1916,6 @@ security = [
     { name = "bandit" },
     { name = "cyclonedx-bom" },
     { name = "pip-audit" },
-    { name = "safety" },
 ]
 
 [package.metadata]
@@ -1988,7 +1957,6 @@ security = [
     { name = "bandit", extras = ["toml"], specifier = ">=1.9.2" },
     { name = "cyclonedx-bom", specifier = ">=7.2.1" },
     { name = "pip-audit", specifier = ">=2.10.0" },
-    { name = "safety", specifier = ">=3.7.0" },
 ]
 
 [[package]]
@@ -2235,21 +2203,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/50/95d7bc91f900da5e22662c82d9bf0f72a4b01f2a552708bf2f43807707a1/nexus_rpc-1.2.0.tar.gz", hash = "sha256:b4ddaffa4d3996aaeadf49b80dfcdfbca48fe4cb616defaf3b3c5c2c8fc61890", size = 74142, upload-time = "2025-11-17T19:17:06.798Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/04/eaac430d0e6bf21265ae989427d37e94be5e41dc216879f1fbb6c5339942/nexus_rpc-1.2.0-py3-none-any.whl", hash = "sha256:977876f3af811ad1a09b2961d3d1ac9233bda43ff0febbb0c9906483b9d9f8a3", size = 28166, upload-time = "2025-11-17T19:17:05.64Z" },
-]
-
-[[package]]
-name = "nltk"
-version = "3.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
 ]
 
 [[package]]
@@ -3463,46 +3416,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.18.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/c7/ee630b29e04a672ecfc9b63227c87fd7a37eb67c1bf30fe95376437f897c/ruamel.yaml-0.18.16.tar.gz", hash = "sha256:a6e587512f3c998b2225d68aa1f35111c29fad14aed561a26e73fab729ec5e5a", size = 147269, upload-time = "2025-10-22T17:54:02.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl", hash = "sha256:048f26d64245bae57a4f9ef6feb5b552a386830ef7a826f235ffb804c59efbba", size = 119858, upload-time = "2025-10-22T17:53:59.012Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
-    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
-    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.8"
 source = { registry = "https://pypi.org/simple" }
@@ -3538,50 +3451,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
-]
-
-[[package]]
-name = "safety"
-version = "3.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "authlib" },
-    { name = "click" },
-    { name = "dparse" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "marshmallow" },
-    { name = "nltk" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "ruamel-yaml" },
-    { name = "safety-schemas" },
-    { name = "tenacity" },
-    { name = "tomlkit" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/e8/1cfffa0d8836de8aa31f4fa7fdeb892c7cfa97cd555039ad5df71ce0e968/safety-3.7.0.tar.gz", hash = "sha256:daec15a393cafc32b846b7ef93f9c952a1708863e242341ab5bde2e4beabb54e", size = 330538, upload-time = "2025-11-06T20:10:15.067Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/55/c4b2058ca346e58124ba082a3596e30dc1f5793710f8173156c7c2d77048/safety-3.7.0-py3-none-any.whl", hash = "sha256:65e71db45eb832e8840e3456333d44c23927423753d5610596a09e909a66d2bf", size = 312436, upload-time = "2025-11-06T20:10:13.576Z" },
-]
-
-[[package]]
-name = "safety-schemas"
-version = "0.0.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dparse" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "ruamel-yaml" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/ef/0e07dfdb4104c4e42ae9fc6e8a0da7be2d72ac2ee198b32f7500796de8f3/safety_schemas-0.0.16.tar.gz", hash = "sha256:3bb04d11bd4b5cc79f9fa183c658a6a8cf827a9ceec443a5ffa6eed38a50a24e", size = 54815, upload-time = "2025-09-16T14:35:31.973Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a2/7840cc32890ce4b84668d3d9dfe15a48355b683ae3fb627ac97ac5a4265f/safety_schemas-0.0.16-py3-none-any.whl", hash = "sha256:6760515d3fd1e6535b251cd73014bd431d12fe0bfb8b6e8880a9379b5ab7aa44", size = 39292, upload-time = "2025-09-16T14:35:32.84Z" },
 ]
 
 [[package]]
@@ -3857,15 +3726,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.13.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We were having `bandit` warnings that were beign ignored because the CI was not failing when running `task security`. This PR changes that behavior