### PR TITLE
Configure Renovate to prevent PR recreation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:recommended"
   ],
+  "recreateWhen": "never",
+  "dependencyDashboard": true,
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## Changes
- Added `recreateWhen: never` to prevent closed PRs from being auto-recreated
- Added `dependencyDashboard: true` to maintain visibility of closed updates in the dependency dashboard

## Why
This allows closing unwanted dependency update PRs (like major version updates) without them becoming "immortal" and auto-recreating. The dependency dashboard will still show all updates, including closed ones, so nothing gets lost.

## How it works
- Close any unwanted Renovate PRs
- They won't be recreated automatically
- Check the "Dependency Dashboard" issue to see all pending updates
- Manually trigger updates from the dashboard when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)