### PR TITLE
Handle remote SSE servers closing POST connections early

### DIFF
--- a/src/mcp_optimizer/config.py
+++ b/src/mcp_optimizer/config.py
@@ -147,7 +147,7 @@ class MCPOptimizerConfig(BaseModel):
 
     # Timeout configuration
     mcp_timeout: int = Field(
-        default=10, ge=1, le=300, description="MCP operation timeout in seconds (1-300)"
+        default=20, ge=1, le=300, description="MCP operation timeout in seconds (1-300)"
     )
 
     # Database configuration


### PR DESCRIPTION
Closes: https://github.com/StacklokLabs/mcp-optimizer/issues/255

- Add tolerant HTTP transport that ignores `httpx.RemoteProtocolError` on POST responses
- Some SSE servers (behind proxies/CDNs) close the POST response connection before the body is sent
- The actual MCP response arrives via the SSE stream, so the POST response body is not needed
- Increase default MCP timeout from 10 to 20 seconds
- Add tests for the tolerant client behavior