### PR TITLE
Add Virtual MCP server support

### DIFF
--- a/examples/mcp-servers/mcpserver_mcp-optimizer-vmcp.yaml
+++ b/examples/mcp-servers/mcpserver_mcp-optimizer-vmcp.yaml
@@ -1,0 +1,109 @@
+# MCP Optimizer configured to work with Virtual MCP Server setup
+# This configuration discovers and aggregates tools from servers in the github-fetch-group
+#
+# Prerequisites:
+# 1. Deploy the vMCP setup first: kubectl apply -f vmcp-github-fetch.yaml
+# 2. Ensure shared-serviceaccount.yaml is deployed
+# 3. GitHub secrets created (see create-github-secrets.sh)
+#
+# Usage:
+#   kubectl apply -f examples/mcp-servers/mcpserver_mcp-optimizer-vmcp.yaml
+#   kubectl port-forward -n toolhive-system svc/mcp-optimizer-proxy 9900:9900
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-optimizer
+  namespace: toolhive-system
+imagePullSecrets:
+  - name: ghcr-pull-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-optimizer-reader
+rules:
+  # Allow reading ToolHive CRDs to discover MCP servers, groups, and virtual servers
+  - apiGroups: ["toolhive.stacklok.dev"]
+    resources: ["mcpservers", "virtualmcpservers", "mcpgroups"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-optimizer-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcp-optimizer-reader
+subjects:
+  - kind: ServiceAccount
+    name: mcp-optimizer
+    namespace: toolhive-system
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: mcp-optimizer
+  namespace: toolhive-system
+spec:
+  image: mcp-optimizer:latest
+  transport: streamable-http
+  proxyMode: streamable-http
+  port: 9900
+  targetPort: 9900
+  serviceAccount: mcp-optimizer
+  permissionProfile:
+    name: network
+    type: builtin
+  podTemplateSpec:
+    spec:
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: mcp
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+          env:
+            - name: SQLITE_TMPDIR
+              value: "/tmp"
+            - name: RUNTIME_MODE
+              value: "k8s"
+            - name: K8S_ALL_NAMESPACES
+              value: "true"
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: WORKLOAD_POLLING_INTERVAL
+              value: "60"
+            - name: REGISTRY_POLLING_INTERVAL
+              value: "300"
+            - name: MAX_TOOLS_TO_RETURN
+              value: "8"
+            - name: MAX_SERVERS_TO_RETURN
+              value: "5"
+            - name: HYBRID_SEARCH_SEMANTIC_RATIO
+              value: "0.5"
+            - name: ASYNC_DB_URL
+              value: "sqlite+aiosqlite:///data/mcp_optimizer.db"
+            - name: DB_URL
+              value: "sqlite:///data/mcp_optimizer.db"
+            # Configure to discover servers in the github-fetch-group
+            - name: ALLOWED_GROUPS
+              value: "github-fetch-group"
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 250m
+      memory: 256Mi

--- a/examples/mcp-servers/vmcp-github-fetch.yaml
+++ b/examples/mcp-servers/vmcp-github-fetch.yaml
@@ -1,0 +1,79 @@
+# Complete vMCP setup with GitHub and Fetch MCP servers
+# This configuration creates a Virtual MCP Server that aggregates
+# GitHub and Fetch backend servers into a single endpoint
+
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPGroup
+metadata:
+  name: github-fetch-group
+  namespace: toolhive-system
+spec:
+  description: "Virtual MCP group with GitHub and Fetch servers"
+
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: github
+  namespace: toolhive-system
+spec:
+  groupRef: github-fetch-group
+  image: ghcr.io/github/github-mcp-server:v0.18.0
+  transport: stdio
+  proxyMode: streamable-http
+  port: 8080
+  targetPort: 8080
+  serviceAccount: mcp-shared-sa
+  permissionProfile:
+    name: network
+    type: builtin
+  secrets:
+    - name: github-token
+      key: token
+      targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: fetch
+  namespace: toolhive-system
+spec:
+  groupRef: github-fetch-group
+  image: ghcr.io/stackloklabs/gofetch/server
+  transport: streamable-http
+  proxyMode: streamable-http
+  port: 8080
+  targetPort: 8080
+  serviceAccount: mcp-shared-sa
+  permissionProfile:
+    name: network
+    type: builtin
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: github-fetch-vmcp
+  namespace: toolhive-system
+spec:
+  config:
+    groupRef: github-fetch-group
+  serviceType: ClusterIP
+  incomingAuth:
+    type: anonymous

--- a/migrations/versions/2025_08_18_0743-d2977d4c8c53_create_initial_tables.py
+++ b/migrations/versions/2025_08_18_0743-d2977d4c8c53_create_initial_tables.py
@@ -68,6 +68,7 @@ def upgrade() -> None:
             description TEXT,
             server_embedding BLOB,
             "group" TEXT NOT NULL DEFAULT 'default',
+            virtual_mcp INTEGER NOT NULL DEFAULT 0,
             last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (registry_server_id)

--- a/src/mcp_optimizer/db/models.py
+++ b/src/mcp_optimizer/db/models.py
@@ -116,6 +116,7 @@ class WorkloadServer(BaseMcpServer):
     status: McpStatus
     registry_server_id: str | None = None  # NULL if autonomous
     registry_server_name: str | None = None  # Cached for tool embedding context
+    virtual_mcp: bool = False  # True for VirtualMCPServer resources, False for regular MCPServer
 
 
 class BaseTool(BaseModel):
@@ -218,6 +219,7 @@ class WorkloadServerUpdateDetails(BaseServerUpdateDetails):
     status: McpStatus | None = None
     registry_server_id: str | None = None
     registry_server_name: str | None = None
+    virtual_mcp: bool | None = None
 
 
 class BaseToolUpdateDetails(BaseUpdateDetails):

--- a/src/mcp_optimizer/db/workload_server_ops.py
+++ b/src/mcp_optimizer/db/workload_server_ops.py
@@ -62,6 +62,7 @@ class WorkloadServerOps(BaseServerOps):
         description: str | None = None,
         server_embedding: np.ndarray | None = None,
         group: str = "default",
+        virtual_mcp: bool = False,
         conn: AsyncConnection | None = None,
     ) -> WorkloadServer:
         """Create a new workload server.
@@ -78,6 +79,7 @@ class WorkloadServerOps(BaseServerOps):
             description: Server description (required if registry_server_id is None)
             server_embedding: Vector embedding (required if registry_server_id is None)
             group: Server grouping (default: "default")
+            virtual_mcp: True for VirtualMCPServer, False for regular MCPServer (default: False)
             conn: Optional connection
 
         Returns:
@@ -101,6 +103,7 @@ class WorkloadServerOps(BaseServerOps):
             description=description,
             server_embedding=server_embedding,
             group=group,
+            virtual_mcp=virtual_mcp,
             last_updated=datetime.now(timezone.utc),
             created_at=datetime.now(timezone.utc),
         )
@@ -109,12 +112,12 @@ class WorkloadServerOps(BaseServerOps):
         INSERT INTO mcpservers_workload (
             id, name, url, workload_identifier, remote, transport, status,
             registry_server_id, registry_server_name, description, server_embedding,
-            "group", last_updated, created_at
+            "group", virtual_mcp, last_updated, created_at
         )
         VALUES (
             :id, :name, :url, :workload_identifier, :remote, :transport, :status,
             :registry_server_id, :registry_server_name, :description, :server_embedding,
-            :group, :last_updated, :created_at
+            :group, :virtual_mcp, :last_updated, :created_at
         )
         """
 

--- a/src/mcp_optimizer/ingestion.py
+++ b/src/mcp_optimizer/ingestion.py
@@ -359,7 +359,7 @@ class IngestionService:
 
         return False
 
-    def _has_workload_server_changed(
+    def _has_workload_server_changed(  # noqa: C901
         self,
         existing_server: "WorkloadServer",
         new_url: str | None = None,
@@ -370,6 +370,7 @@ class IngestionService:
         new_registry_server_id: str | None = None,
         new_description: str | None = None,
         new_embedding: np.ndarray | None = None,
+        new_virtual_mcp: bool | None = None,
     ) -> bool:
         """Check if workload server attributes have changed (US3).
 
@@ -383,6 +384,7 @@ class IngestionService:
             new_registry_server_id: New registry server ID (None means unlinked)
             new_description: New description
             new_embedding: New embedding
+            new_virtual_mcp: New virtual_mcp flag
 
         Returns:
             True if any attribute has changed, False otherwise
@@ -412,6 +414,8 @@ class IngestionService:
         if new_embedding is not None and not self._compare_embeddings(
             existing_server.server_embedding, new_embedding
         ):
+            return True
+        if new_virtual_mcp is not None and existing_server.virtual_mcp != new_virtual_mcp:
             return True
 
         return False
@@ -731,6 +735,7 @@ class IngestionService:
                 new_group=workload.group or "default",
                 new_registry_server_id=registry_server_id,
                 new_workload_identifier=workload.package,
+                new_virtual_mcp=workload.virtual_mcp or False,
             )
 
             if not server_has_changed:
@@ -749,6 +754,7 @@ class IngestionService:
                 "group": workload.group or "default",
                 "registry_server_id": registry_server_id,
                 "registry_server_name": registry_server_name,
+                "virtual_mcp": workload.virtual_mcp or False,
             }
 
             # If linked to registry, use registry metadata
@@ -816,6 +822,7 @@ class IngestionService:
                 group=workload.group or "default",
                 registry_server_id=registry_server_id,
                 registry_server_name=registry_server_name,
+                virtual_mcp=workload.virtual_mcp or False,
                 conn=conn,
             )
 

--- a/src/mcp_optimizer/toolhive/api_models/core.py
+++ b/src/mcp_optimizer/toolhive/api_models/core.py
@@ -58,3 +58,7 @@ class Workload(BaseModel):
         None,
         description='URL is the URL of the workload exposed by the ToolHive proxy.',
     )
+    virtual_mcp: bool | None = Field(
+        None,
+        description='VirtualMCP indicates whether this is a virtual MCP server resource (true) or a regular MCP server (false).',
+    )


### PR DESCRIPTION
- Added virtual_mcp field to workload server model and database schema
- Implemented intelligent group filtering: prioritizes virtual MCP servers when present in a group, falls back to all servers when absent
- Updated tool discovery, search, and token counting to respect virtual MCP hierarchy
- Enhanced k8s client to detect VirtualMCPServer resources and configure transport/URLs correctly
- Added RBAC permissions for reading virtualmcpservers and mcpgroups CRDs
- Created vmcp-github-fetch.yaml example with complete MCPGroup, backend servers, and VirtualMCPServer configuration
- Created mcpserver_mcp-optimizer-vmcp.yaml for deploying MCP Optimizer with vMCP support
- Updated documentation with vMCP setup instructions and usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)