### PR TITLE
Fix brittle exception handling in ingestion and polling pipelines

### DIFF
--- a/src/mcp_optimizer/ingestion.py
+++ b/src/mcp_optimizer/ingestion.py
@@ -1228,7 +1228,7 @@ class IngestionService:
                 server_name=server_metadata.name,
                 error=str(e),
             )
-            raise e
+            raise
 
     async def _ingest_registry_servers(  # noqa: C901
         self, registry: Registry, conn: AsyncConnection
@@ -1588,13 +1588,13 @@ class IngestionService:
                     error_type=type(e).__name__,
                 )
                 raise ToolHiveUnavailable("ToolHive server unavailable") from e
-            # For other errors, log warning and re-raise
+            # For other errors, log warning and raise as IngestionError
             logger.warning(
                 "Failed to fetch registry",
                 error=str(e),
                 error_type=type(e).__name__,
             )
-            raise
+            raise IngestionError(f"Failed to fetch registry: {e}") from e
 
     async def _get_all_workloads(self, toolhive_client: ToolhiveClient) -> list[Workload]:
         """Fetch all MCP workloads based on runtime mode.
@@ -1647,6 +1647,13 @@ class IngestionService:
                 "Will retry on next polling cycle."
             )
             return
+        except Exception as e:
+            logger.exception(
+                "Unexpected error fetching workloads - skipping ingestion cycle",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return
 
         # Fetch workload details for remote workloads to get accurate URLs
         # This is critical for URL-based matching instead of package-based matching
@@ -1680,106 +1687,115 @@ class IngestionService:
         # follow this pattern. Pass the `conn` object to all ops methods to ensure
         # they participate in the same transaction. Without this pattern, operations
         # execute independently and may result in partial updates on failure.
-        async with self.db_config.begin_transaction() as conn:
-            try:
-                if not all_workloads:
-                    logger.warning("No MCP workloads found in ToolHive")
-                    # Clean up all servers since none exist in ToolHive
-                    deleted_server_names = await self._cleanup_removed_servers(set(), conn)
-                else:
-                    # Extract workload identifiers for cleanup
-                    workload_identifiers = set()
-                    for workload in all_workloads:
-                        workload_identifiers.add(workload.name)
+        try:
+            async with self.db_config.begin_transaction() as conn:
+                try:
+                    if not all_workloads:
+                        logger.warning("No MCP workloads found in ToolHive")
+                        # Clean up all servers since none exist in ToolHive
+                        deleted_server_names = await self._cleanup_removed_servers(set(), conn)
+                    else:
+                        # Extract workload identifiers for cleanup
+                        workload_identifiers = set()
+                        for workload in all_workloads:
+                            workload_identifiers.add(workload.name)
 
-                    # Filter out workloads that should be skipped
-                    workloads_to_process = [
-                        workload
-                        for workload in all_workloads
-                        if not self._should_skip_workload(workload)
-                    ]
+                        # Filter out workloads that should be skipped
+                        workloads_to_process = [
+                            workload
+                            for workload in all_workloads
+                            if not self._should_skip_workload(workload)
+                        ]
 
-                    # Log skipped workloads
-                    for workload in all_workloads:
-                        skip_reason = self._get_skip_reason(workload)
-                        if skip_reason:
-                            log_level = (
-                                logger.warning
-                                if "missing or empty name" in skip_reason
-                                else logger.debug
-                            )
-                            log_level(
-                                "Skipping workload during ingestion",
-                                workload_name=workload.name or "<no name>",
-                                reason=skip_reason,
-                            )
+                        # Log skipped workloads
+                        for workload in all_workloads:
+                            skip_reason = self._get_skip_reason(workload)
+                            if skip_reason:
+                                log_level = (
+                                    logger.warning
+                                    if "missing or empty name" in skip_reason
+                                    else logger.debug
+                                )
+                                log_level(
+                                    "Skipping workload during ingestion",
+                                    workload_name=workload.name or "<no name>",
+                                    reason=skip_reason,
+                                )
 
-                    # Process all workloads in batches
-                    process_tasks = [
-                        self._process_workload(workload, conn) for workload in workloads_to_process
-                    ]
-                    results = await self._batch_gather(
-                        process_tasks, self.workload_ingestion_batch_size
-                    )
+                        # Process all workloads in batches
+                        process_tasks = [
+                            self._process_workload(workload, conn)
+                            for workload in workloads_to_process
+                        ]
+                        results = await self._batch_gather(
+                            process_tasks, self.workload_ingestion_batch_size
+                        )
 
-                    # Process results
-                    for workload, result in zip(workloads_to_process, results, strict=True):
-                        if isinstance(result, Exception):
-                            failed += 1
-                            logger.exception(
-                                f"Failed to process workload '{workload.name}' in transaction",
-                                workload_name=workload.name,
-                                workload_remote=workload.remote or False,
-                                workload_url=workload.url,
-                                workload_package=workload.package,
-                                error=str(result),
-                                error_type=type(result).__name__,
-                            )
-                        elif result["status"] == "success":
-                            num_ingested += result["was_updated"]
-                            total_tools += result["tools_count"]
-                            logger.debug(
-                                "Successfully processed workload",
-                                workload_name=workload.name,
-                                workload_remote=workload.remote or False,
-                                tools_count=result["tools_count"],
-                            )
-                        else:
-                            failed += 1
-                            logger.warning(
-                                "Failed to process workload - see details above",
-                                workload_name=workload.name,
-                                workload_remote=workload.remote or False,
-                                workload_url=workload.url,
-                                error=result.get("error"),
-                            )
+                        # Process results
+                        for workload, result in zip(workloads_to_process, results, strict=True):
+                            if isinstance(result, Exception):
+                                failed += 1
+                                logger.exception(
+                                    f"Failed to process workload '{workload.name}' in transaction",
+                                    workload_name=workload.name,
+                                    workload_remote=workload.remote or False,
+                                    workload_url=workload.url,
+                                    workload_package=workload.package,
+                                    error=str(result),
+                                    error_type=type(result).__name__,
+                                )
+                            elif result["status"] == "success":
+                                num_ingested += result["was_updated"]
+                                total_tools += result["tools_count"]
+                                logger.debug(
+                                    "Successfully processed workload",
+                                    workload_name=workload.name,
+                                    workload_remote=workload.remote or False,
+                                    tools_count=result["tools_count"],
+                                )
+                            else:
+                                failed += 1
+                                logger.warning(
+                                    "Failed to process workload - see details above",
+                                    workload_name=workload.name,
+                                    workload_remote=workload.remote or False,
+                                    workload_url=workload.url,
+                                    error=result.get("error"),
+                                )
 
-                    # Clean up servers that are no longer in ToolHive
-                    deleted_server_names = await self._cleanup_removed_servers(
-                        workload_identifiers, conn
-                    )
+                        # Clean up servers that are no longer in ToolHive
+                        deleted_server_names = await self._cleanup_removed_servers(
+                            workload_identifiers, conn
+                        )
 
-                # Only sync vector tables if there were changes
-                # (successful ingestions or deleted servers indicate changes)
-                if num_ingested > 0 or deleted_server_names:
-                    logger.info(
-                        "Synchronizing workload vector tables after ingestion",
-                        successful_ingestions=num_ingested,
-                        deleted_servers=len(deleted_server_names),
-                    )
-                    # Sync workload server and tool vectors
-                    await self.workload_server_ops.sync_server_vectors(conn=conn)
-                    await self.workload_tool_ops.sync_tool_vectors(conn=conn)
+                    # Only sync vector tables if there were changes
+                    # (successful ingestions or deleted servers indicate changes)
+                    if num_ingested > 0 or deleted_server_names:
+                        logger.info(
+                            "Synchronizing workload vector tables after ingestion",
+                            successful_ingestions=num_ingested,
+                            deleted_servers=len(deleted_server_names),
+                        )
+                        # Sync workload server and tool vectors
+                        await self.workload_server_ops.sync_server_vectors(conn=conn)
+                        await self.workload_tool_ops.sync_tool_vectors(conn=conn)
 
-                    # Sync FTS table for BM25 search (workload tools only)
-                    await self.workload_tool_ops.sync_tool_fts(conn=conn)
-                    logger.info("Workload vector and FTS synchronization completed")
-                else:
-                    logger.info("Workload ingestion: no changes detected, skipping vector sync")
+                        # Sync FTS table for BM25 search (workload tools only)
+                        await self.workload_tool_ops.sync_tool_fts(conn=conn)
+                        logger.info("Workload vector and FTS synchronization completed")
+                    else:
+                        logger.info("Workload ingestion: no changes detected, skipping vector sync")
 
-            except Exception as e:
-                logger.exception("Transaction failed, rolling back all changes", error=str(e))
-                raise  # Re-raise to trigger rollback
+                except Exception as e:
+                    logger.error("Transaction failed, rolling back all changes", error=str(e))
+                    raise  # Re-raise to trigger rollback
+        except Exception as e:
+            logger.exception(
+                "Workload ingestion transaction failed - will retry on next cycle",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return
 
     async def ingest_registry(self, toolhive_client: ToolhiveClient) -> None:
         """Ingest registry servers from Toolhive.
@@ -1822,6 +1838,13 @@ class IngestionService:
                 "Will retry on next polling cycle."
             )
             return
+        except Exception as e:
+            logger.exception(
+                "Unexpected error fetching registry - skipping ingestion cycle",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return
 
         # Wrap all database operations in a single transaction for atomicity.
         # This ensures all registry server ingestions and vector table updates
@@ -1830,35 +1853,44 @@ class IngestionService:
         # TRANSACTION PATTERN: All database operations requiring atomicity should
         # follow this pattern. Pass the `conn` object to all ops methods to ensure
         # they participate in the same transaction.
-        async with self.db_config.begin_transaction() as conn:
-            try:
-                # Ingest all registry servers
-                registry_servers_count = 0
-                if registry:
-                    registry_servers_count = await self._ingest_registry_servers(registry, conn)
-                    logger.info(
-                        "Ingested registry servers", registry_servers_count=registry_servers_count
-                    )
-                else:
-                    logger.warning("No registry available to ingest")
+        try:
+            async with self.db_config.begin_transaction() as conn:
+                try:
+                    # Ingest all registry servers
+                    registry_servers_count = 0
+                    if registry:
+                        registry_servers_count = await self._ingest_registry_servers(registry, conn)
+                        logger.info(
+                            "Ingested registry servers",
+                            registry_servers_count=registry_servers_count,
+                        )
+                    else:
+                        logger.warning("No registry available to ingest")
 
-                # Only sync vector tables if there were changes
-                # (successful registry server ingestions indicate changes)
-                if registry_servers_count > 0:
-                    logger.info(
-                        "Synchronizing registry vector tables after ingestion",
-                        registry_servers_ingested=registry_servers_count,
-                    )
-                    # Sync registry server and tool vectors
-                    await self.registry_server_ops.sync_server_vectors(conn=conn)
-                    await self.registry_tool_ops.sync_tool_vectors(conn=conn)
+                    # Only sync vector tables if there were changes
+                    # (successful registry server ingestions indicate changes)
+                    if registry_servers_count > 0:
+                        logger.info(
+                            "Synchronizing registry vector tables after ingestion",
+                            registry_servers_ingested=registry_servers_count,
+                        )
+                        # Sync registry server and tool vectors
+                        await self.registry_server_ops.sync_server_vectors(conn=conn)
+                        await self.registry_tool_ops.sync_tool_vectors(conn=conn)
 
-                    # Sync FTS table for BM25 search (registry tools)
-                    await self.registry_tool_ops.sync_tool_fts(conn=conn)
-                    logger.info("Registry vector and FTS synchronization completed")
-                else:
-                    logger.info("Registry ingestion: no changes detected, skipping vector sync")
+                        # Sync FTS table for BM25 search (registry tools)
+                        await self.registry_tool_ops.sync_tool_fts(conn=conn)
+                        logger.info("Registry vector and FTS synchronization completed")
+                    else:
+                        logger.info("Registry ingestion: no changes detected, skipping vector sync")
 
-            except Exception as e:
-                logger.exception("Transaction failed, rolling back all changes", error=str(e))
-                raise  # Re-raise to trigger rollback
+                except Exception as e:
+                    logger.error("Transaction failed, rolling back all changes", error=str(e))
+                    raise  # Re-raise to trigger rollback
+        except Exception as e:
+            logger.exception(
+                "Registry ingestion transaction failed - will retry on next cycle",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return

--- a/src/mcp_optimizer/mcp_client.py
+++ b/src/mcp_optimizer/mcp_client.py
@@ -291,6 +291,15 @@ class MCPServerClient:
                 error=str(e),
             )
             raise WorkloadConnectionError(f"MCP protocol error: {e}") from e
+        except Exception as e:
+            # Catch-all for unexpected transport-level errors (httpx, OSError, etc.)
+            logger.error(
+                "Unexpected error during MCP session",
+                workload=self.workload,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            raise WorkloadConnectionError(f"Unexpected session error: {e}") from e
 
     async def _execute_streamable_session(
         self, operation: Callable[[ClientSession], Awaitable], url: str

--- a/src/mcp_optimizer/polling_manager.py
+++ b/src/mcp_optimizer/polling_manager.py
@@ -372,11 +372,8 @@ class PollingManager:
 
         # ALWAYS run first poll (startup run is mandatory)
         logger.info("Running initial workload polling (startup)")
-        try:
-            await self._poll_workloads()
-            logger.info("Initial workload polling completed successfully")
-        except Exception as e:
-            logger.exception("Error during initial workload polling", error=str(e))
+        await self._poll_workloads()
+        logger.info("Initial workload polling completed successfully")
 
         # If interval <= 0, stop after initial run
         if self.workload_polling_interval <= 0:
@@ -418,14 +415,8 @@ class PollingManager:
                 cycle=cycle_count,
                 interval=self.workload_polling_interval,
             )
-            try:
-                await self._poll_workloads()
-                logger.info("Workload polling cycle completed successfully", cycle=cycle_count)
-            except Exception as e:
-                logger.exception(
-                    "Error during workload polling cycle", error=str(e), cycle=cycle_count
-                )
-                # Continue polling even if one cycle fails
+            await self._poll_workloads()
+            logger.info("Workload polling cycle completed successfully", cycle=cycle_count)
 
         logger.info("Workload polling loop ended", total_cycles=cycle_count)
 
@@ -442,11 +433,8 @@ class PollingManager:
 
         # ALWAYS run first poll (startup run is mandatory)
         logger.info("Running initial registry polling (startup)")
-        try:
-            await self._poll_registry()
-            logger.info("Initial registry polling completed successfully")
-        except Exception as e:
-            logger.exception("Error during initial registry polling", error=str(e))
+        await self._poll_registry()
+        logger.info("Initial registry polling completed successfully")
 
         # Signal workload polling that registry startup is complete
         if self._registry_startup_complete is not None:
@@ -479,14 +467,8 @@ class PollingManager:
                 cycle=cycle_count,
                 interval=self.registry_polling_interval,
             )
-            try:
-                await self._poll_registry()
-                logger.info("Registry polling cycle completed successfully", cycle=cycle_count)
-            except Exception as e:
-                logger.exception(
-                    "Error during registry polling cycle", error=str(e), cycle=cycle_count
-                )
-                # Continue polling even if one cycle fails
+            await self._poll_registry()
+            logger.info("Registry polling cycle completed successfully", cycle=cycle_count)
 
         logger.info("Registry polling loop ended", total_cycles=cycle_count)
 
@@ -498,23 +480,27 @@ class PollingManager:
             # Use the ingestion service to sync all workloads
             await self.ingestion_service.ingest_workloads(self.toolhive_client)
             logger.debug("Workload polling cycle completed successfully")
-        except Exception as e:
+        except (
+            ToolhiveConnectionError,
+            ToolhiveScanError,
+            ConnectionError,
+            ToolHiveUnavailable,
+        ) as e:
             # Handle ToolHive unavailability gracefully - log and continue polling
             # This allows the system to reconnect when ToolHive becomes available
-            if isinstance(
-                e,
-                (ToolhiveConnectionError, ToolhiveScanError, ConnectionError, ToolHiveUnavailable),
-            ):
-                logger.warning(
-                    "ToolHive unavailable during polling. Will retry on next polling cycle.",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-                # Don't re-raise - continue polling so we can reconnect later
-                return
-            logger.exception("Error during workload synchronization", error=str(e))
-            # Re-raise unexpected errors
-            raise
+            logger.warning(
+                "ToolHive unavailable during polling. Will retry on next polling cycle.",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+        except Exception as e:
+            # Log unexpected errors but never re-raise to keep the polling loop alive
+            logger.exception(
+                "Unexpected error during workload synchronization. "
+                "Will retry on next polling cycle.",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
 
     async def _poll_registry(self) -> None:
         """Poll ToolHive and synchronize the database with registry servers."""
@@ -524,23 +510,27 @@ class PollingManager:
             # Use the ingestion service to sync registry servers
             await self.ingestion_service.ingest_registry(self.toolhive_client)
             logger.debug("Registry polling cycle completed successfully")
-        except Exception as e:
+        except (
+            ToolhiveConnectionError,
+            ToolhiveScanError,
+            ConnectionError,
+            ToolHiveUnavailable,
+        ) as e:
             # Handle ToolHive unavailability gracefully - log and continue polling
             # This allows the system to reconnect when ToolHive becomes available
-            if isinstance(
-                e,
-                (ToolhiveConnectionError, ToolhiveScanError, ConnectionError, ToolHiveUnavailable),
-            ):
-                logger.warning(
-                    "ToolHive unavailable during polling. Will retry on next polling cycle.",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-                # Don't re-raise - continue polling so we can reconnect later
-                return
-            logger.exception("Error during registry synchronization", error=str(e))
-            # Re-raise unexpected errors
-            raise
+            logger.warning(
+                "ToolHive unavailable during polling. Will retry on next polling cycle.",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+        except Exception as e:
+            # Log unexpected errors but never re-raise to keep the polling loop alive
+            logger.exception(
+                "Unexpected error during registry synchronization. "
+                "Will retry on next polling cycle.",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
 
     def is_polling(self) -> bool:
         """Check if polling is currently active."""

--- a/src/mcp_optimizer/toolhive/toolhive_client.py
+++ b/src/mcp_optimizer/toolhive/toolhive_client.py
@@ -440,6 +440,9 @@ class ToolhiveClient:
             for attempt in range(self.max_retries):
                 try:
                     return await func(*args, **kwargs)
+                # Only httpx transport errors are retried; any other exception
+                # propagates immediately. The caller (_execute_with_session)
+                # converts those to WorkloadConnectionError for per-workload isolation.
                 except (
                     httpx.ConnectError,
                     httpx.ConnectTimeout,

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -174,22 +174,26 @@ class TestPollingManager:
         mock_ingest_registry.assert_called_once_with(polling_manager.toolhive_client)
 
     async def test_poll_and_sync_with_error(self, polling_manager):
-        """Test that polling continues even if sync fails."""
+        """Test that polling swallows unexpected errors to keep the loop alive."""
         # Mock the ingestion service to raise an error
         mock_ingest = AsyncMock(side_effect=Exception("Test error"))
         polling_manager.ingestion_service.ingest_workloads = mock_ingest
 
-        # Should raise the exception
-        with pytest.raises(Exception, match="Test error"):
-            await polling_manager._poll_workloads()
+        # Should NOT raise - unexpected errors are swallowed to keep polling alive
+        await polling_manager._poll_workloads()
 
     async def test_polling_loop_with_error(self, polling_manager):
-        """Test that polling loop continues even if individual cycles fail."""
+        """Test that polling loop continues even if individual cycles fail.
+
+        _poll_workloads swallows all exceptions internally, so the loop
+        keeps running even when the underlying ingestion service raises.
+        We mock at the ingest_workloads level to verify this end-to-end.
+        """
         call_count = 0
         first_call_event = asyncio.Event()
         second_call_event = asyncio.Event()
 
-        async def mock_poll_workloads():
+        async def mock_ingest_workloads(_client):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -205,14 +209,17 @@ class TestPollingManager:
             if polling_manager._registry_startup_complete:
                 polling_manager._registry_startup_complete.set()
 
-        with (
-            patch.object(polling_manager, "_poll_workloads", side_effect=mock_poll_workloads),
-            patch.object(polling_manager, "_registry_polling_loop", side_effect=mock_registry_loop),
+        polling_manager.ingestion_service.ingest_workloads = AsyncMock(
+            side_effect=mock_ingest_workloads
+        )
+
+        with patch.object(
+            polling_manager, "_registry_polling_loop", side_effect=mock_registry_loop
         ):
             # Start polling
             await polling_manager.start_polling()
 
-            # Wait for the first call to complete (which should fail)
+            # Wait for the first call to complete (which should fail but be swallowed)
             await asyncio.wait_for(first_call_event.wait(), timeout=1.0)
 
             # Wait for the second call to complete (which should succeed)


### PR DESCRIPTION
## Summary
- Add catch-all `except Exception` in `mcp_client.py` `_execute_with_session()` to convert unexpected transport errors (httpx, OSError, etc.) into `WorkloadConnectionError` for per-workload isolation
- Add catch-all handlers in `ingestion.py` for workload/registry fetch stages and transaction blocks so unexpected errors skip the cycle instead of crashing
- Refactor `polling_manager.py` to use explicit multi-except clauses instead of `isinstance()` checks, and swallow unexpected errors to keep the polling loop alive
- Remove dead `try/except` wrappers in polling loop methods since `_poll_workloads`/`_poll_registry` now handle errors internally
- Fix `raise e` to bare `raise` in ingestion.py to preserve tracebacks
- Wrap generic exceptions as `IngestionError` in `_get_registry` for typed handling
- Fix double-logging in nested transaction handlers (inner uses `logger.error`, outer uses `logger.exception`)
- Update tests to match new swallow-all behavior

Closes #365

## Test plan
- [x] All 306 existing tests pass
- [x] `task lint`, `task format`, `task typecheck` all clean
- [ ] Verify polling loop survives unexpected exceptions (e.g., SSL errors, DNS failures) in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)