### PR TITLE
Validate workloads individually to prevent single-workload outages

### DIFF
--- a/src/mcp_optimizer/toolhive/k8s_client.py
+++ b/src/mcp_optimizer/toolhive/k8s_client.py
@@ -165,7 +165,15 @@ class K8sClient:
         else:
             # Regular MCPServer - get transport from spec
             transport_str = spec.get("transport", "stdio")
-            transport_type = TransportType(transport_str) if transport_str else None
+            try:
+                transport_type = TransportType(transport_str) if transport_str else None
+            except ValueError:
+                logger.warning(
+                    "Unknown transport type in K8s workload, defaulting to None",
+                    workload_name=name,
+                    transport_type=transport_str,
+                )
+                transport_type = None
 
         # Map k8s phase to workload status
         # Phases: Pending, Running, Failed, Unknown (MCPServer)

--- a/src/mcp_optimizer/toolhive/toolhive_client.py
+++ b/src/mcp_optimizer/toolhive/toolhive_client.py
@@ -557,10 +557,38 @@ class ToolhiveClient:
             response.raise_for_status()
 
             data = response.json()
-            workload_list = WorkloadListResponse.model_validate(data)
-            if workload_list is None or workload_list.workloads is None:
+
+            raw_workloads = data.get("workloads") if isinstance(data, dict) else None
+            if not isinstance(raw_workloads, list):
                 logger.warning("No workloads found", all_workloads=all_workloads)
                 return WorkloadListResponse(workloads=[])
+
+            # Validate workloads individually so one bad workload
+            # (e.g. unknown transport_type) doesn't kill discovery of all others.
+            valid_workloads: list[Workload] = []
+            for i, raw_workload in enumerate(raw_workloads):
+                try:
+                    valid_workloads.append(Workload.model_validate(raw_workload))
+                except Exception as e:
+                    name = (
+                        raw_workload.get("name", f"index-{i}")
+                        if isinstance(raw_workload, dict)
+                        else f"index-{i}"
+                    )
+                    logger.warning(
+                        "Skipping workload with invalid data",
+                        workload_name=name,
+                        error=str(e),
+                        exc_info=False,
+                    )
+
+            skipped_count = len(raw_workloads) - len(valid_workloads)
+            if skipped_count:
+                logger.warning(
+                    f"Failed to validate {skipped_count} out of "
+                    f"{len(raw_workloads)} workloads. "
+                    f"Returning {len(valid_workloads)} valid workloads.",
+                )
 
             # Replace the localhost/127.0.0.1 host with the toolhive host
             # This is required since in docker/podman container, we cannot use
@@ -568,7 +596,7 @@ class ToolhiveClient:
             # Only replace when actually running in Docker to avoid breaking
             # local runs when TOOLHIVE_HOST is set to host.docker.internal
             if _is_running_in_docker() and self.thv_host not in ("localhost", "127.0.0.1"):
-                for workload in workload_list.workloads:
+                for workload in valid_workloads:
                     if workload.url:
                         parsed_url = urlparse(workload.url)
                         workload_host = parsed_url.hostname
@@ -577,11 +605,11 @@ class ToolhiveClient:
 
             logger.info(
                 "Successfully fetched workloads",
-                count=len(workload_list.workloads),
+                count=len(valid_workloads),
                 all_workloads=all_workloads,
             )
 
-            return workload_list
+            return WorkloadListResponse(workloads=valid_workloads)
 
         return await self._with_retry(_list_workloads_impl)()
 

--- a/tests/test_k8s_client.py
+++ b/tests/test_k8s_client.py
@@ -1,0 +1,61 @@
+"""Tests for the Kubernetes client."""
+
+from mcp_optimizer.toolhive.k8s_client import K8sClient
+
+
+def test_mcpserver_to_workload_unknown_transport_type():
+    """Test that _mcpserver_to_workload handles unknown transport types gracefully."""
+    k8s_client = K8sClient()
+
+    mcpserver = {
+        "metadata": {
+            "name": "test-server",
+            "namespace": "default",
+            "creationTimestamp": "2025-01-01T00:00:00Z",
+        },
+        "spec": {
+            "image": "test/server:latest",
+            "transport": "grpc",
+            "port": 8080,
+        },
+        "status": {
+            "phase": "Running",
+            "url": "http://127.0.0.1:8080",
+        },
+    }
+
+    # Should not raise — unknown transport defaults to None
+    workload = k8s_client._mcpserver_to_workload(mcpserver)
+
+    assert workload.name == "test-server"
+    assert workload.transport_type is None
+    assert workload.status == "running"
+
+
+def test_mcpserver_to_workload_empty_transport_type():
+    """Test that _mcpserver_to_workload handles empty transport string."""
+    k8s_client = K8sClient()
+
+    mcpserver = {
+        "metadata": {
+            "name": "empty-transport",
+            "namespace": "default",
+            "creationTimestamp": "2025-01-01T00:00:00Z",
+        },
+        "spec": {
+            "image": "test/server:latest",
+            "transport": "",
+            "port": 8080,
+        },
+        "status": {
+            "phase": "Running",
+            "url": "http://127.0.0.1:8080",
+        },
+    }
+
+    # Empty string is falsy, so takes the `else None` path without hitting TransportType()
+    workload = k8s_client._mcpserver_to_workload(mcpserver)
+
+    assert workload.name == "empty-transport"
+    assert workload.transport_type is None
+    assert workload.status == "running"

--- a/tests/test_toolhive_client.py
+++ b/tests/test_toolhive_client.py
@@ -638,3 +638,203 @@ async def test_get_workload_details_timeout(toolhive_client):
         # Call the method and expect an exception
         with pytest.raises(httpx.TimeoutException):
             await client.get_workload_details("test-server")
+
+
+# Tests for workload validation resilience
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_skips_invalid_transport_type(toolhive_client):
+    """Test that a workload with an unknown transport_type is skipped, not fatal."""
+    response_data = {
+        "workloads": [
+            {
+                "name": "valid-server",
+                "package": "test/valid:latest",
+                "url": "http://127.0.0.1:8080/sse#valid-server",
+                "port": 8080,
+                "transport_type": "stdio",
+                "status": "running",
+            },
+            {
+                "name": "bad-transport-server",
+                "package": "test/bad:latest",
+                "url": "http://127.0.0.1:8081/sse#bad-server",
+                "port": 8081,
+                "transport_type": "grpc",
+                "status": "running",
+            },
+            {
+                "name": "another-valid-server",
+                "package": "test/valid2:latest",
+                "url": "http://127.0.0.1:8082/sse#valid2",
+                "port": 8082,
+                "transport_type": "sse",
+                "status": "running",
+            },
+        ]
+    }
+
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify valid workloads are returned and invalid one is skipped
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 2
+        names = [w.name for w in result.workloads]
+        assert "valid-server" in names
+        assert "another-valid-server" in names
+        assert "bad-transport-server" not in names
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_empty_transport_type(toolhive_client):
+    """Test that a workload with transport_type='' is skipped (the original bug)."""
+    response_data = {
+        "workloads": [
+            {
+                "name": "good-server",
+                "package": "test/good:latest",
+                "url": "http://127.0.0.1:8080/sse#good",
+                "port": 8080,
+                "transport_type": "stdio",
+                "status": "running",
+            },
+            {
+                "name": "zombie-workload",
+                "package": "test/zombie:latest",
+                "url": "http://127.0.0.1:8081/sse#zombie",
+                "port": 8081,
+                "transport_type": "",
+                "status": "running",
+            },
+        ]
+    }
+
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify the invalid workload is skipped
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 1
+        assert result.workloads[0].name == "good-server"
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_all_invalid(toolhive_client):
+    """Test that all-invalid workloads returns empty list, not an exception."""
+    response_data = {
+        "workloads": [
+            {
+                "name": "bad-1",
+                "transport_type": "unknown-type",
+            },
+            {
+                "name": "bad-2",
+                "transport_type": "",
+            },
+        ]
+    }
+
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify empty list returned, not an exception
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_missing_workloads_key(toolhive_client):
+    """Test that a response missing the 'workloads' key returns empty list."""
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify the result
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_null_workloads_value(toolhive_client):
+    """Test that a response with workloads=null returns empty list."""
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = {"workloads": None}
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify the result
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_workloads_non_dict_entry_in_list(toolhive_client):
+    """Test that a non-dict entry in the workloads list is skipped."""
+    response_data = {
+        "workloads": [
+            "not-a-dict",
+            {
+                "name": "valid-server",
+                "package": "test/valid:latest",
+                "url": "http://127.0.0.1:8080/sse#valid",
+                "port": 8080,
+                "transport_type": "stdio",
+                "status": "running",
+            },
+        ]
+    }
+
+    async with toolhive_client as client:
+        # Mock the HTTP client
+        mock_response = Mock()
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = Mock()
+
+        client._client.get = AsyncMock(return_value=mock_response)
+
+        # Call the method
+        result = await client.list_workloads()
+
+        # Verify the non-dict entry is skipped and the valid one survives
+        assert isinstance(result, WorkloadListResponse)
+        assert len(result.workloads) == 1
+        assert result.workloads[0].name == "valid-server"


### PR DESCRIPTION
## Summary

- Replace atomic `WorkloadListResponse.model_validate()` with per-workload validation that skips invalid entries with a warning, following the existing `_tool_conversion` pattern in `server.py`
- Add summary log when workloads are skipped (count of skipped vs total)
- Wrap `TransportType()` construction in `k8s_client.py` to handle unknown transport types gracefully (defaults to `None`)
- Add 7 tests for validation resilience in `test_toolhive_client.py` and new `test_k8s_client.py`

Fixes #398

## Test plan

- [x] `task format` — no issues
- [x] `task lint` — all checks passed
- [x] `task typecheck` — all checks passed
- [x] `task test` — 306 tests passed
- [x] Local Docker test against real ToolHive — container fetched 51 workloads, MCP session and tool listing work

🤖 Generated with [Claude Code](https://claude.com/claude-code)